### PR TITLE
feat(tools): add UTM builder — branded campaign link tagger

### DIFF
--- a/.github/workflows/dbt-docs.yml
+++ b/.github/workflows/dbt-docs.yml
@@ -1,19 +1,19 @@
-name: dbt docs
+name: publish site
 
-# Rebuilds the onchain-analytics dbt docs site and publishes it to the
-# gh-pages branch under /onchain-analytics/
-# (served at https://gooddollar.github.io/data-team/onchain-analytics/).
+# Rebuilds and deploys all tools/docs to GitHub Pages:
+#   - dbt docs  → /onchain-analytics/  (gooddollar.github.io/data-team/onchain-analytics/)
+#   - UTM builder → /utm-builder/      (gooddollar.github.io/data-team/utm-builder/)
 #
-# Runs on pushes to master that touch the dbt project, and on manual dispatch.
-# The docs are built with --empty-catalog, so NO BigQuery credentials are
-# needed — the lineage graph, model/column descriptions, tests, and compiled
-# SQL all come from the code, not the warehouse.
+# Runs on pushes to master that touch either the dbt project or the UTM builder,
+# and on manual dispatch. The dbt docs build uses --empty-catalog so NO BigQuery
+# credentials are needed — lineage, descriptions, and compiled SQL come from code.
 
 on:
   push:
     branches: [master]
     paths:
       - 'projects/onchain-analytics/gd_dbt/**'
+      - 'tools/utm-builder/**'
       - '.github/workflows/dbt-docs.yml'
   workflow_dispatch:
 
@@ -79,10 +79,14 @@ jobs:
           # Deploy dbt docs into /onchain-analytics/ subfolder
           mkdir -p "$tmp/onchain-analytics"
           cp source/projects/onchain-analytics/gd_dbt/target/static_index.html "$tmp/onchain-analytics/index.html"
+          # Deploy UTM builder tool into /utm-builder/ subfolder
+          mkdir -p "$tmp/utm-builder"
+          cp source/tools/utm-builder/index.html "$tmp/utm-builder/index.html"
+          cp source/tools/utm-builder/config.json "$tmp/utm-builder/config.json"
           touch "$tmp/.nojekyll"
           git -C "$tmp" init -q -b gh-pages
           git -C "$tmp" config user.name "github-actions[bot]"
           git -C "$tmp" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git -C "$tmp" add .
-          git -C "$tmp" commit -q -m "docs: publish dbt docs [skip ci]"
+          git -C "$tmp" commit -q -m "docs: publish site [skip ci]"
           git -C "$tmp" push -f "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" gh-pages

--- a/README.md
+++ b/README.md
@@ -11,14 +11,17 @@ The central hub for GoodDollar's analytics and data work. This repo contains the
 ```
 data-team/
 ├── projects/
-│   ├── gd-events-pipeline/   # On-chain event pipeline (TypeScript, BigQuery)
-│   │   └── docs/
-│   │       └── layer2-entities/  # L2 invite entity reference
+│   ├── onchain-analytics/    # On-chain analytics system (dbt + HyperSync pipeline, BigQuery)
 │   ├── dashboard-scripts/    # GoodDollar main dashboard (Google Apps Script)
+│   ├── weekly-report/        # Weekly data report automation
 │   └── automations/          # n8n automation flows (archived)
 ├── queries/
 │   └── dune/                 # Dune Analytics SQL queries
+├── tools/
+│   └── utm-builder/          # UTM link builder — live at gooddollar.github.io/data-team/utm-builder/
 └── docs/
+    ├── data-dictionary/      # Data dictionary and definitions
+    ├── datasources/          # Data source documentation
     ├── subgraph/             # GoodDollar subgraph schemas
     └── dashboards.md         # Links to live dashboards
 ```
@@ -29,8 +32,17 @@ data-team/
 
 | Project | Description | Status |
 |---|---|---|
-| [gd-events-pipeline](projects/gd-events-pipeline/) | Indexes on-chain GoodDollar events into BigQuery via HyperSync | Active |
+| [onchain-analytics](projects/onchain-analytics/) | 3-layer BigQuery warehouse (Staging → Semantic → Marts) fed by HyperSync, with dbt transformations. Powers all on-chain dashboards and reporting. | Active |
 | [dashboard-scripts](projects/dashboard-scripts/) | Google Apps Script powering the GoodDollar main dashboard | Active (v6) |
+| [weekly-report](projects/weekly-report/) | Weekly data report automation | Active |
+
+---
+
+## Documentation
+
+- **[dbt Docs Site](https://gooddollar.github.io/data-team/onchain-analytics/)** — browsable data catalog with model lineage, column descriptions, and business glossary (auto-published from `projects/onchain-analytics/gd_dbt/`)
+- **[UTM Builder](https://gooddollar.github.io/data-team/utm-builder/)** — browser-based tool for generating tracked campaign URLs. See the [UTM naming standard](tools/utm-builder/UTM_STANDARD.md) for the full convention.
+- **[docs/](docs/)** — data dictionary, data source documentation, subgraph schemas
 
 ---
 

--- a/tools/utm-builder/README.md
+++ b/tools/utm-builder/README.md
@@ -1,0 +1,33 @@
+# GoodDollar UTM Builder
+
+A browser-based form for generating correctly-formatted UTM tracking URLs — no free-typing, no typos, no broken attribution.
+
+**→ [Open the UTM Builder](https://gooddollar.github.io/data-team/utm-builder/)**
+
+---
+
+## Quick reference
+
+Campaign name format:
+
+```
+<initiative>-<goal>-<YYYY_MM>-<name>
+```
+
+Example: `antseed-acquisition-2026_07-ai_credits_launch`
+
+See [UTM_STANDARD.md](UTM_STANDARD.md) for the full naming standard, per-channel quick references, and governance.
+
+---
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `index.html` | The tool — self-contained, no build step, no dependencies |
+| `config.json` | Controlled dropdown values (sources, mediums, initiatives, goals) |
+| `UTM_STANDARD.md` | Full naming standard, user guide, and governance |
+
+## Updating the taxonomy
+
+Edit `config.json` + update the matching table in `UTM_STANDARD.md` → open a PR. The tool reloads values from `config.json` at runtime — no build step needed.

--- a/tools/utm-builder/UTM_STANDARD.md
+++ b/tools/utm-builder/UTM_STANDARD.md
@@ -1,0 +1,233 @@
+# GoodDollar UTM Naming Standard
+*Version 1.0 — July 2026. Owner: Thales (Data). Applies to: all teams, all campaigns, all channels.*
+
+---
+
+## Why This Exists
+
+Every link we share externally (social, email, Telegram, partner) should tell us **who clicked it, why, and from where**. Without UTMs, every visit looks like "direct" — zero attribution, zero insight into what's working.
+
+This document defines **the one naming convention** the entire org uses. It's not optional, it's not per-project — it's the shared language that makes our analytics coherent.
+
+---
+
+## The Rules (Non-Negotiable)
+
+| Rule | Why |
+|------|-----|
+| **Lowercase everything** | `Twitter` ≠ `twitter` in analytics. Pick one. We picked lowercase. |
+| **Never UTM internal links** | UTMs on links *within* our own sites destroy attribution. External-inbound only. |
+| **Always set all 3 core params** | Source + medium + campaign. Missing any one = broken data. |
+| **Use the builder, not free-typing** | The [UTM Builder tool](https://gooddollar.github.io/data-team/utm-builder/) prevents typos and fragmentation. |
+| **Dash between fields, underscore within words** | `antseed-acquisition-2026_07-launch_post` — always parseable. |
+
+---
+
+## The 3 Core Parameters
+
+### `utm_source` — Who sent the traffic
+
+The platform, partner, or channel that sent the click.
+
+**Controlled values (use ONLY these):**
+
+| Value | When to use |
+|-------|-------------|
+| `twitter` | Any post or link on X/Twitter |
+| `telegram` | Telegram group, channel, or bot |
+| `linkedin` | LinkedIn posts or messages |
+| `facebook` | Facebook posts or ads |
+| `discord` | Discord channel links |
+| `email` | Newsletter, transactional, onboarding emails |
+| `minipay` | Links from MiniPay integration |
+| `valora` | Links from Valora |
+| `fonbnk` | Links from Fonbnk |
+| `antseed` | Links from AntSeed properties |
+| `gooddapp` | Links from GoodDapp to GoodWallet |
+| `community` | Community-generated content (ambassadors, UGC) |
+| `partner_<name>` | Any other partner (e.g., `partner_kipu`) |
+| `qr_<context>` | Physical QR codes (e.g., `qr_ethcc_booth`) |
+
+> **Adding a new source:** [Open a data request](https://github.com/GoodDollar/data-team/issues/new?template=data-request.md) on the data-team repo. We'll add it to the builder and this list.
+
+---
+
+### `utm_medium` — Channel type
+
+How the traffic reached us. Maps to standard channel groupings.
+
+**Controlled values (use ONLY these):**
+
+| Value | Meaning |
+|-------|---------|
+| `social` | Organic social media posts |
+| `paid_social` | Paid social ads |
+| `email` | Email of any kind |
+| `referral` | Blog posts, news articles, external sites linking to us |
+| `partner` | Partner app/integration links |
+| `cpc` | Paid search (Google Ads, etc.) |
+| `banner` | Display/banner ads |
+| `push` | Push notifications |
+| `sms` | SMS messages |
+| `in_app` | In-app banners or notifications (only if they open a new session) |
+
+---
+
+### `utm_campaign` — Structured campaign name
+
+This is where the intelligence lives. **Not free text** — it follows a structure:
+
+```
+<initiative>-<goal>-<date>-<name>
+```
+
+| Field | Type | Values |
+|-------|------|--------|
+| `initiative` | Dropdown | `ubi`, `antseed`, `builders`, `governance`, `general`, `minipay`, `superfluid` |
+| `goal` | Dropdown | `awareness`, `acquisition`, `activation`, `retention`, `revenue` |
+| `date` | Fixed format | `YYYY_MM` (when campaign launched) |
+| `name` | Free text | snake_case, specific identifier |
+
+**Examples:**
+```
+antseed-acquisition-2026_07-ai_credits_launch
+ubi-awareness-2026_07-twitter_thread_series
+governance-activation-2026_07-dao_vote_reminder
+builders-acquisition-2026_08-season4_recruitment
+superfluid-activation-2026_08-stream_tutorial
+```
+
+**Why this structure?** Because you can filter:
+- `antseed-*` = everything Antseed
+- `*-acquisition-*` = all acquisition campaigns
+- `*-2026_07-*` = everything from July
+- Regex is trivial. Reporting is trivial.
+
+---
+
+## Optional Parameters
+
+### `utm_content` — Creative/variant differentiation
+
+Use when you have multiple links in the same campaign pointing to the same page.
+
+```
+Format: snake_case, free text
+Examples: banner_top, cta_blue, video_30s, thread_01, bio_link
+```
+
+### `utm_term` — Paid search keyword
+
+Only relevant if/when we run paid search campaigns. Ignore until then.
+
+---
+
+## How to Generate a Tagged URL
+
+### Step 1: Use the URL Builder
+
+**→ [gooddollar.github.io/data-team/utm-builder](https://gooddollar.github.io/data-team/utm-builder/)**
+
+The builder has dropdown validation for source, medium, initiative, and goal. You type only the destination URL, the `name`, and optional `content`. It auto-generates the full tagged URL with copy-to-clipboard.
+
+### Step 2: Shorten if needed
+
+Long UTM URLs look ugly in social posts. Use a shortener (Bitly, or our branded `go.gooddollar.org` when available). The UTMs survive through the redirect.
+
+### Step 3: Share the shortened or full link
+
+Never edit the UTM params after generating. If you need a variant, generate a new URL.
+
+---
+
+## Per-Channel Quick Reference
+
+### Social (Twitter, Telegram, LinkedIn, Discord)
+```
+utm_source:   twitter | telegram | linkedin | discord
+utm_medium:   social
+utm_campaign: <initiative>-<goal>-<date>-<name>
+utm_content:  thread_01 | post_video | bio_link | pinned_tweet (optional)
+```
+
+### Email
+```
+utm_source:   email
+utm_medium:   email
+utm_campaign: <initiative>-<goal>-<date>-<name>
+utm_content:  header_cta | footer_link | inline_button (optional)
+```
+
+### Partner Integrations
+```
+utm_source:   minipay | valora | fonbnk | antseed | partner_<name>
+utm_medium:   partner
+utm_campaign: <initiative>-<goal>-<date>-<name>
+utm_content:  app_banner | push_notification | in_app_card (optional)
+```
+
+### QR Codes
+```
+utm_source:   qr_<location_context>
+utm_medium:   referral
+utm_campaign: <initiative>-<goal>-<date>-<name>
+utm_content:  poster_a4 | badge_back | screen_booth (optional)
+```
+
+---
+
+## What This Enables
+
+Once links are tagged consistently:
+
+| Question | How it's answered |
+|----------|-------------------|
+| "Which channel drives the most wallet signups?" | Filter by `utm_medium` → conversion events |
+| "Is the Antseed launch campaign working?" | Filter `utm_campaign` starts with `antseed-` |
+| "Which Telegram post drove the most claims?" | Filter `utm_source=telegram` + `utm_content` |
+| "How much traffic comes from partners vs organic?" | Group by `utm_medium` |
+| "What's our acquisition cost per channel?" | `utm_medium` + spend data |
+
+---
+
+## Governance
+
+| What | Who | How |
+|------|-----|-----|
+| Add new source/medium values | Thales (Data) | [Open a data request](https://github.com/GoodDollar/data-team/issues/new?template=data-request.md) |
+| Add new initiative values | Thales + requestor | [Open a data request](https://github.com/GoodDollar/data-team/issues/new?template=data-request.md) |
+| Annual audit (check for rogue values) | Thales | January each year |
+| URL Builder maintenance | Thales | [data-team repo](https://github.com/GoodDollar/data-team) |
+
+## Maintaining the taxonomy
+
+The builder loads its dropdown values from [`config.json`](config.json) at runtime. To add, rename, or remove a tag value:
+
+1. Edit `config.json` — add or remove objects in the relevant array (`sources`, `mediums`, `initiatives`, `goals`). Each object needs a `value` (the raw UTM string, lowercase) and a `label` (display name in the dropdown).
+2. Update the corresponding table in this document so the written standard stays in sync.
+3. Open a PR — the live tool updates as soon as it merges to master.
+
+No build step. The tool is plain HTML + JavaScript with zero dependencies.
+
+---
+
+## FAQ
+
+**Q: Do I need to UTM-tag every single link I share?**
+A: Every *external* link that drives traffic to our properties (goodwallet.xyz, gooddapp.org, ai-credits-web.vercel.app, etc). Not internal links. Not links to external sites.
+
+**Q: What if my campaign doesn't fit an initiative?**
+A: Use `general`. If it keeps happening, we add a new initiative value.
+
+**Q: Can I make up my own source/medium?**
+A: No. Use the controlled values. If something's missing, [open a data request](https://github.com/GoodDollar/data-team/issues/new?template=data-request.md) and we'll add it.
+
+**Q: Telegram strips my UTMs — what do I do?**
+A: Use a shortener (Bitly, or our branded short link when available). The redirect preserves params through Telegram's link handler.
+
+**Q: What about the AI credits widget specifically?**
+A: See the companion doc: *Antseed AI Credits — Tracking Plan* (covers the full funnel including on-chain and backend metrics beyond UTMs).
+
+---
+
+*Last updated: 2026-07-08. Next review: 2026-08-01.*

--- a/tools/utm-builder/config.json
+++ b/tools/utm-builder/config.json
@@ -1,0 +1,45 @@
+{
+  "sources": [
+    { "value": "twitter", "label": "Twitter / X" },
+    { "value": "telegram", "label": "Telegram" },
+    { "value": "linkedin", "label": "LinkedIn" },
+    { "value": "facebook", "label": "Facebook" },
+    { "value": "discord", "label": "Discord" },
+    { "value": "email", "label": "Email" },
+    { "value": "minipay", "label": "MiniPay" },
+    { "value": "valora", "label": "Valora" },
+    { "value": "fonbnk", "label": "Fonbnk" },
+    { "value": "antseed", "label": "AntSeed" },
+    { "value": "gooddapp", "label": "GoodDapp" },
+    { "value": "goodwallet", "label": "GoodWallet" },
+    { "value": "community", "label": "Community / UGC" }
+  ],
+  "mediums": [
+    { "value": "social", "label": "Organic Social" },
+    { "value": "paid_social", "label": "Paid Social" },
+    { "value": "email", "label": "Email" },
+    { "value": "referral", "label": "Referral" },
+    { "value": "partner", "label": "Partner" },
+    { "value": "cpc", "label": "Paid Search (CPC)" },
+    { "value": "banner", "label": "Display / Banner" },
+    { "value": "push", "label": "Push Notification" },
+    { "value": "sms", "label": "SMS" },
+    { "value": "in_app", "label": "In-App" }
+  ],
+  "initiatives": [
+    { "value": "ubi", "label": "UBI" },
+    { "value": "antseed", "label": "AntSeed / AI Credits" },
+    { "value": "builders", "label": "GoodBuilders" },
+    { "value": "governance", "label": "Governance" },
+    { "value": "general", "label": "General" },
+    { "value": "minipay", "label": "MiniPay" },
+    { "value": "superfluid", "label": "Superfluid" }
+  ],
+  "goals": [
+    { "value": "awareness", "label": "Awareness" },
+    { "value": "acquisition", "label": "Acquisition" },
+    { "value": "activation", "label": "Activation" },
+    { "value": "retention", "label": "Retention" },
+    { "value": "revenue", "label": "Revenue" }
+  ]
+}

--- a/tools/utm-builder/index.html
+++ b/tools/utm-builder/index.html
@@ -1,0 +1,850 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>GoodDollar UTM Builder</title>
+  <style>
+    :root {
+      --gd-green: #00B0A0;
+      --gd-green-dark: #00D4C0;
+      --gd-green-light: rgba(0, 176, 160, 0.1);
+      --text: #e4e4e7;
+      --text-secondary: #a1a1aa;
+      --text-muted: #71717a;
+      --border: #2e2e38;
+      --bg: #0f0f14;
+      --card-bg: #1a1a24;
+      --input-bg: #12121a;
+      --error: #f87171;
+      --radius: 10px;
+      --success: #34d399;
+    }
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Inter, Roboto, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.5;
+      min-height: 100vh;
+    }
+
+    .container {
+      max-width: 740px;
+      margin: 0 auto;
+      padding: 2.5rem 1.5rem;
+    }
+
+    header {
+      text-align: center;
+      margin-bottom: 2.5rem;
+    }
+
+    header h1 {
+      font-size: 1.75rem;
+      font-weight: 700;
+      color: var(--text);
+      margin-bottom: 0.35rem;
+    }
+
+    header h1 span {
+      color: var(--gd-green);
+    }
+
+    header p {
+      color: var(--text-secondary);
+      font-size: 0.9rem;
+    }
+
+    header a {
+      color: var(--gd-green-dark);
+      text-decoration: none;
+    }
+
+    header a:hover {
+      text-decoration: underline;
+    }
+
+    .card {
+      background: var(--card-bg);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 1.5rem;
+      margin-bottom: 1.25rem;
+    }
+
+    .card-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 1rem;
+    }
+
+    .card-header h2 {
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.75px;
+      color: var(--text-secondary);
+    }
+
+    .card-header .badge {
+      font-size: 0.65rem;
+      padding: 0.2rem 0.5rem;
+      border-radius: 4px;
+      background: var(--gd-green-light);
+      color: var(--gd-green-dark);
+      font-weight: 500;
+    }
+
+    .tooltip-trigger {
+      position: relative;
+      display: inline-flex;
+      align-items: center;
+      cursor: help;
+    }
+
+    .tooltip-icon {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 16px;
+      height: 16px;
+      border-radius: 50%;
+      background: var(--border);
+      color: var(--text-muted);
+      font-size: 0.6rem;
+      font-weight: 700;
+      margin-left: 0.4rem;
+      flex-shrink: 0;
+    }
+
+    .tooltip-content {
+      position: absolute;
+      bottom: calc(100% + 8px);
+      left: 50%;
+      transform: translateX(-50%);
+      background: #2a2a36;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 0.6rem 0.75rem;
+      font-size: 0.75rem;
+      font-weight: 400;
+      color: var(--text-secondary);
+      width: 260px;
+      opacity: 0;
+      visibility: hidden;
+      transition: opacity 0.15s, visibility 0.15s;
+      z-index: 50;
+      line-height: 1.4;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+    }
+
+    .tooltip-content::after {
+      content: '';
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      border: 5px solid transparent;
+      border-top-color: #2a2a36;
+    }
+
+    .tooltip-trigger:hover .tooltip-content {
+      opacity: 1;
+      visibility: visible;
+    }
+
+    .field {
+      margin-bottom: 1rem;
+    }
+
+    .field:last-child {
+      margin-bottom: 0;
+    }
+
+    label {
+      display: flex;
+      align-items: center;
+      font-size: 0.82rem;
+      font-weight: 600;
+      margin-bottom: 0.4rem;
+      color: var(--text);
+    }
+
+    label .hint {
+      font-weight: 400;
+      color: var(--text-muted);
+      margin-left: 0.4rem;
+    }
+
+    select, input[type="text"], input[type="url"] {
+      width: 100%;
+      padding: 0.6rem 0.75rem;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      font-size: 0.88rem;
+      color: var(--text);
+      background: var(--input-bg);
+      transition: border-color 0.15s;
+    }
+
+    select:focus, input:focus {
+      outline: none;
+      border-color: var(--gd-green);
+      box-shadow: 0 0 0 3px rgba(0, 176, 160, 0.12);
+    }
+
+    select { cursor: pointer; }
+
+    select option {
+      background: var(--card-bg);
+      color: var(--text);
+    }
+
+    .row {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1rem;
+    }
+
+    @media (max-width: 500px) {
+      .row { grid-template-columns: 1fr; }
+    }
+
+    .campaign-preview {
+      margin-top: 0.75rem;
+      padding: 0.55rem 0.75rem;
+      background: var(--gd-green-light);
+      border: 1px solid rgba(0, 176, 160, 0.2);
+      border-radius: 6px;
+      font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+      font-size: 0.78rem;
+      color: var(--gd-green-dark);
+      word-break: break-all;
+    }
+
+    .output-url {
+      width: 100%;
+      padding: 0.75rem;
+      background: var(--input-bg);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+      font-size: 0.78rem;
+      word-break: break-all;
+      min-height: 70px;
+      color: var(--gd-green-dark);
+      resize: vertical;
+    }
+
+    .btn-row {
+      display: flex;
+      gap: 0.75rem;
+      margin-top: 1rem;
+    }
+
+    .btn {
+      padding: 0.65rem 1.5rem;
+      border: none;
+      border-radius: 6px;
+      font-size: 0.85rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: all 0.15s;
+    }
+
+    .btn-primary {
+      background: var(--gd-green);
+      color: #0f0f14;
+    }
+
+    .btn-primary:hover {
+      background: var(--gd-green-dark);
+    }
+
+    .btn-primary:disabled {
+      background: #2e2e38;
+      color: var(--text-muted);
+      cursor: not-allowed;
+    }
+
+    .btn-secondary {
+      background: transparent;
+      color: var(--text-secondary);
+      border: 1px solid var(--border);
+    }
+
+    .btn-secondary:hover {
+      background: rgba(255,255,255,0.04);
+      border-color: var(--text-muted);
+    }
+
+    .toast {
+      position: fixed;
+      bottom: 2rem;
+      left: 50%;
+      transform: translateX(-50%) translateY(100px);
+      background: var(--success);
+      color: #0f0f14;
+      padding: 0.65rem 1.5rem;
+      border-radius: 6px;
+      font-size: 0.85rem;
+      font-weight: 600;
+      opacity: 0;
+      transition: all 0.3s;
+      z-index: 100;
+    }
+
+    .toast.show {
+      opacity: 1;
+      transform: translateX(-50%) translateY(0);
+    }
+
+    .error-msg {
+      color: var(--error);
+      font-size: 0.75rem;
+      margin-top: 0.3rem;
+      display: none;
+    }
+
+    .error-msg.visible {
+      display: block;
+    }
+
+    /* Reference section */
+    .reference {
+      margin-top: 2rem;
+    }
+
+    .reference summary {
+      cursor: pointer;
+      font-size: 0.82rem;
+      font-weight: 600;
+      color: var(--text-secondary);
+      padding: 0.75rem 1rem;
+      background: var(--card-bg);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      list-style: none;
+    }
+
+    .reference summary::-webkit-details-marker { display: none; }
+
+    .reference summary::before {
+      content: '+ ';
+      color: var(--gd-green);
+      font-weight: 700;
+    }
+
+    .reference[open] summary::before {
+      content: '- ';
+    }
+
+    .reference[open] summary {
+      border-radius: var(--radius) var(--radius) 0 0;
+      border-bottom: none;
+    }
+
+    .reference .ref-content {
+      background: var(--card-bg);
+      border: 1px solid var(--border);
+      border-top: none;
+      border-radius: 0 0 var(--radius) var(--radius);
+      padding: 1.25rem;
+    }
+
+    .ref-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1.25rem;
+    }
+
+    @media (max-width: 500px) {
+      .ref-grid { grid-template-columns: 1fr; }
+    }
+
+    .ref-group h3 {
+      font-size: 0.7rem;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      color: var(--text-muted);
+      margin-bottom: 0.5rem;
+      font-weight: 600;
+    }
+
+    .ref-group ul {
+      list-style: none;
+      padding: 0;
+    }
+
+    .ref-group li {
+      font-size: 0.76rem;
+      padding: 0.2rem 0;
+      color: var(--text-secondary);
+    }
+
+    .ref-group li code {
+      background: var(--input-bg);
+      padding: 0.1rem 0.4rem;
+      border-radius: 3px;
+      font-family: 'SF Mono', 'Fira Code', monospace;
+      font-size: 0.7rem;
+      color: var(--gd-green-dark);
+      margin-right: 0.35rem;
+      border: 1px solid var(--border);
+    }
+
+    footer {
+      text-align: center;
+      margin-top: 2rem;
+      color: var(--text-muted);
+      font-size: 0.78rem;
+      line-height: 1.8;
+    }
+
+    footer a {
+      color: var(--gd-green-dark);
+      text-decoration: none;
+    }
+
+    footer a:hover {
+      text-decoration: underline;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <header>
+      <h1>GoodDollar <span>UTM Builder</span></h1>
+      <p>Generate tagged campaign URLs following the <a href="https://github.com/GoodDollar/data-team/blob/master/tools/utm-builder/UTM_STANDARD.md">UTM Master Standard</a>.</p>
+    </header>
+
+    <!-- Destination URL -->
+    <div class="card">
+      <div class="card-header">
+        <h2>Destination</h2>
+      </div>
+      <div class="field">
+        <label for="url">
+          Page URL
+          <span class="tooltip-trigger">
+            <span class="tooltip-icon">?</span>
+            <span class="tooltip-content">The page you want people to land on. Usually goodwallet.xyz, gooddapp.org, or ai-credits-web.vercel.app. Must start with https://</span>
+          </span>
+        </label>
+        <input type="url" id="url" placeholder="https://goodwallet.xyz">
+        <div class="error-msg" id="url-error">Enter a valid URL starting with https://</div>
+      </div>
+    </div>
+
+    <!-- Source & Medium -->
+    <div class="card">
+      <div class="card-header">
+        <h2>Source &amp; Medium</h2>
+        <span class="badge">Required</span>
+      </div>
+      <div class="row">
+        <div class="field">
+          <label for="source">
+            Source
+            <span class="tooltip-trigger">
+              <span class="tooltip-icon">?</span>
+              <span class="tooltip-content">Where is the traffic coming from? Pick the platform or partner that will display the link. E.g. if you're posting on Telegram, select "Telegram".</span>
+            </span>
+          </label>
+          <select id="source" required>
+            <option value="">Select source...</option>
+          </select>
+        </div>
+        <div class="field">
+          <label for="medium">
+            Medium
+            <span class="tooltip-trigger">
+              <span class="tooltip-icon">?</span>
+              <span class="tooltip-content">What type of channel is this? "Social" for organic posts, "Email" for newsletters, "Partner" for app integrations. This groups traffic into categories for reporting.</span>
+            </span>
+          </label>
+          <select id="medium" required>
+            <option value="">Select medium...</option>
+          </select>
+        </div>
+      </div>
+      <div class="field" id="custom-source-field" style="display:none; margin-top:1rem;">
+        <label for="custom-source">Custom source name <span class="hint">(lowercase, e.g. partner_kipu)</span></label>
+        <input type="text" id="custom-source" placeholder="partner_name">
+      </div>
+    </div>
+
+    <!-- Campaign -->
+    <div class="card">
+      <div class="card-header">
+        <h2>Campaign</h2>
+        <span class="badge">Required</span>
+      </div>
+      <div class="row">
+        <div class="field">
+          <label for="initiative">
+            Initiative
+            <span class="tooltip-trigger">
+              <span class="tooltip-icon">?</span>
+              <span class="tooltip-content">Which project or product area does this campaign promote? Select the one that best fits. Use "General" if it's a broad GoodDollar campaign not tied to a specific product.</span>
+            </span>
+          </label>
+          <select id="initiative" required>
+            <option value="">Select initiative...</option>
+          </select>
+        </div>
+        <div class="field">
+          <label for="goal">
+            Goal
+            <span class="tooltip-trigger">
+              <span class="tooltip-icon">?</span>
+              <span class="tooltip-content"><strong>Awareness</strong> = people learn we exist. <strong>Acquisition</strong> = new signups. <strong>Activation</strong> = existing users try a feature. <strong>Retention</strong> = bring back inactive users. <strong>Revenue</strong> = drive purchases.</span>
+            </span>
+          </label>
+          <select id="goal" required>
+            <option value="">Select goal...</option>
+          </select>
+        </div>
+      </div>
+      <div class="row" style="margin-top:1rem;">
+        <div class="field">
+          <label for="date">
+            Date
+            <span class="tooltip-trigger">
+              <span class="tooltip-icon">?</span>
+              <span class="tooltip-content">When this campaign launches. Auto-filled to the current month. Change it only if scheduling for a different month.</span>
+            </span>
+          </label>
+          <input type="text" id="date" placeholder="2026_07">
+        </div>
+        <div class="field">
+          <label for="name">
+            Campaign name
+            <span class="tooltip-trigger">
+              <span class="tooltip-icon">?</span>
+              <span class="tooltip-content">A short, specific name for this campaign. Use underscores between words, no spaces. Examples: launch_announcement, weekly_thread, claim_day_promo</span>
+            </span>
+          </label>
+          <input type="text" id="name" placeholder="launch_announcement" required>
+          <div class="error-msg" id="name-error">Use lowercase letters, numbers, and underscores only</div>
+        </div>
+      </div>
+      <div class="campaign-preview" id="campaign-preview">
+        <em style="color: var(--text-muted);">Campaign tag will appear here as you type...</em>
+      </div>
+    </div>
+
+    <!-- Content (optional) -->
+    <div class="card">
+      <div class="card-header">
+        <h2>Content</h2>
+        <span class="badge" style="background:rgba(255,255,255,0.05); color:var(--text-muted);">Optional</span>
+      </div>
+      <div class="field">
+        <label for="content">
+          Variant / placement
+          <span class="tooltip-trigger">
+            <span class="tooltip-icon">?</span>
+            <span class="tooltip-content">Use this when you share multiple links for the same campaign. For example: thread_01, thread_02, thread_03 for a Twitter thread. Or banner_top vs cta_bottom for email links.</span>
+          </span>
+        </label>
+        <input type="text" id="content" placeholder="e.g. thread_01, banner_top, cta_blue">
+      </div>
+    </div>
+
+    <!-- Output -->
+    <div class="card">
+      <div class="card-header">
+        <h2>Generated URL</h2>
+      </div>
+      <textarea class="output-url" id="output" readonly placeholder="Fill in the fields above to generate your tagged URL..."></textarea>
+      <div class="btn-row">
+        <button class="btn btn-primary" id="copy-btn" disabled>Copy to clipboard</button>
+        <button class="btn btn-secondary" id="reset-btn">Reset</button>
+      </div>
+    </div>
+
+    <!-- Reference (collapsible) -->
+    <details class="reference" id="reference-section">
+      <summary>Show all valid values (quick reference)</summary>
+      <div class="ref-content">
+        <div class="ref-grid" id="ref-grid"></div>
+      </div>
+    </details>
+
+    <footer>
+      <p>
+        Read the full <a href="https://github.com/GoodDollar/data-team/blob/master/tools/utm-builder/UTM_STANDARD.md">UTM Master Standard</a> for rules and governance.
+      </p>
+      <p>
+        Need a new option? <a href="https://github.com/GoodDollar/data-team/issues/new">Open a data request</a> on the data-team repo.
+      </p>
+    </footer>
+  </div>
+
+  <div class="toast" id="toast">Copied!</div>
+
+  <script>
+    // Config inlined so it works locally (file://) and on GH Pages.
+    // On GH Pages, config.json is also fetched as an override.
+    const CONFIG = {
+      "sources": [
+        { "value": "twitter", "label": "Twitter / X" },
+        { "value": "telegram", "label": "Telegram" },
+        { "value": "linkedin", "label": "LinkedIn" },
+        { "value": "facebook", "label": "Facebook" },
+        { "value": "discord", "label": "Discord" },
+        { "value": "email", "label": "Email" },
+        { "value": "minipay", "label": "MiniPay" },
+        { "value": "valora", "label": "Valora" },
+        { "value": "fonbnk", "label": "Fonbnk" },
+        { "value": "antseed", "label": "AntSeed" },
+        { "value": "gooddapp", "label": "GoodDapp" },
+        { "value": "goodwallet", "label": "GoodWallet" },
+        { "value": "community", "label": "Community / UGC" }
+      ],
+      "mediums": [
+        { "value": "social", "label": "Organic Social" },
+        { "value": "paid_social", "label": "Paid Social" },
+        { "value": "email", "label": "Email" },
+        { "value": "referral", "label": "Referral" },
+        { "value": "partner", "label": "Partner" },
+        { "value": "cpc", "label": "Paid Search (CPC)" },
+        { "value": "banner", "label": "Display / Banner" },
+        { "value": "push", "label": "Push Notification" },
+        { "value": "sms", "label": "SMS" },
+        { "value": "in_app", "label": "In-App" }
+      ],
+      "initiatives": [
+        { "value": "ubi", "label": "UBI" },
+        { "value": "antseed", "label": "AntSeed / AI Credits" },
+        { "value": "builders", "label": "GoodBuilders" },
+        { "value": "governance", "label": "Governance" },
+        { "value": "general", "label": "General" },
+        { "value": "minipay", "label": "MiniPay" },
+        { "value": "superfluid", "label": "Superfluid" }
+      ],
+      "goals": [
+        { "value": "awareness", "label": "Awareness" },
+        { "value": "acquisition", "label": "Acquisition" },
+        { "value": "activation", "label": "Activation" },
+        { "value": "retention", "label": "Retention" },
+        { "value": "revenue", "label": "Revenue" }
+      ]
+    };
+
+    (async function() {
+      // Try fetch for GH Pages; fall back to inline for local
+      let config = CONFIG;
+      try {
+        const resp = await fetch('config.json');
+        if (resp.ok) config = await resp.json();
+      } catch (e) { /* use inline */ }
+
+      // Populate dropdowns
+      const sourceSelect = document.getElementById('source');
+      const mediumSelect = document.getElementById('medium');
+      const initiativeSelect = document.getElementById('initiative');
+      const goalSelect = document.getElementById('goal');
+
+      config.sources.forEach(s => {
+        const opt = document.createElement('option');
+        opt.value = s.value;
+        opt.textContent = s.label;
+        sourceSelect.appendChild(opt);
+      });
+      const customOpt = document.createElement('option');
+      customOpt.value = '__custom__';
+      customOpt.textContent = 'Other (custom)...';
+      sourceSelect.appendChild(customOpt);
+
+      config.mediums.forEach(m => {
+        const opt = document.createElement('option');
+        opt.value = m.value;
+        opt.textContent = m.label;
+        mediumSelect.appendChild(opt);
+      });
+
+      config.initiatives.forEach(i => {
+        const opt = document.createElement('option');
+        opt.value = i.value;
+        opt.textContent = i.label;
+        initiativeSelect.appendChild(opt);
+      });
+
+      config.goals.forEach(g => {
+        const opt = document.createElement('option');
+        opt.value = g.value;
+        opt.textContent = g.label;
+        goalSelect.appendChild(opt);
+      });
+
+      // Default date
+      const now = new Date();
+      const yyyy = now.getFullYear();
+      const mm = String(now.getMonth() + 1).padStart(2, '0');
+      document.getElementById('date').value = yyyy + '_' + mm;
+
+      // Build reference grid
+      const refGrid = document.getElementById('ref-grid');
+      const groups = [
+        { title: 'Sources (utm_source)', items: config.sources },
+        { title: 'Mediums (utm_medium)', items: config.mediums },
+        { title: 'Initiatives', items: config.initiatives },
+        { title: 'Goals', items: config.goals }
+      ];
+      groups.forEach(function(group) {
+        const div = document.createElement('div');
+        div.className = 'ref-group';
+        let html = '<h3>' + group.title + '</h3><ul>';
+        group.items.forEach(function(item) {
+          html += '<li><code>' + item.value + '</code> ' + item.label + '</li>';
+        });
+        html += '</ul>';
+        div.innerHTML = html;
+        refGrid.appendChild(div);
+      });
+
+      // Custom source toggle
+      sourceSelect.addEventListener('change', function() {
+        var customField = document.getElementById('custom-source-field');
+        customField.style.display = sourceSelect.value === '__custom__' ? 'block' : 'none';
+        update();
+      });
+
+      function validateName(val) {
+        return /^[a-z0-9_]*$/.test(val);
+      }
+
+      function validateUrl(val) {
+        try {
+          var url = new URL(val);
+          return url.protocol === 'https:' || url.protocol === 'http:';
+        } catch (e) {
+          return false;
+        }
+      }
+
+      function getSource() {
+        if (sourceSelect.value === '__custom__') {
+          return document.getElementById('custom-source').value.trim().toLowerCase().replace(/\s+/g, '_');
+        }
+        return sourceSelect.value;
+      }
+
+      function update() {
+        var url = document.getElementById('url').value.trim();
+        var source = getSource();
+        var medium = mediumSelect.value;
+        var initiative = initiativeSelect.value;
+        var goal = goalSelect.value;
+        var date = document.getElementById('date').value.trim();
+        var nameRaw = document.getElementById('name').value.trim();
+        var name = nameRaw.toLowerCase().replace(/\s+/g, '_');
+        var contentRaw = document.getElementById('content').value.trim();
+        var content = contentRaw.toLowerCase().replace(/\s+/g, '_');
+
+        // Campaign preview
+        var preview = document.getElementById('campaign-preview');
+        if (initiative && goal && date && name) {
+          preview.innerHTML = '<strong>utm_campaign</strong> = ' + initiative + '-' + goal + '-' + date + '-' + name;
+        } else {
+          preview.innerHTML = '<em style="color: var(--text-muted);">Campaign tag will appear here as you type...</em>';
+        }
+
+        // Validate name
+        var nameError = document.getElementById('name-error');
+        if (nameRaw && !validateName(name)) {
+          nameError.classList.add('visible');
+        } else {
+          nameError.classList.remove('visible');
+        }
+
+        // Validate URL
+        var urlError = document.getElementById('url-error');
+        if (url && !validateUrl(url)) {
+          urlError.classList.add('visible');
+        } else {
+          urlError.classList.remove('visible');
+        }
+
+        // Generate output
+        var output = document.getElementById('output');
+        var copyBtn = document.getElementById('copy-btn');
+
+        if (!url || !source || !medium || !initiative || !goal || !name) {
+          output.value = '';
+          copyBtn.disabled = true;
+          return;
+        }
+
+        if (!validateUrl(url) || (nameRaw && !validateName(name))) {
+          output.value = '';
+          copyBtn.disabled = true;
+          return;
+        }
+
+        var campaign = initiative + '-' + goal + '-' + date + '-' + name;
+        var params = new URLSearchParams();
+        params.set('utm_source', source);
+        params.set('utm_medium', medium);
+        params.set('utm_campaign', campaign);
+        if (content && validateName(content)) {
+          params.set('utm_content', content);
+        }
+
+        var separator = url.includes('?') ? '&' : '?';
+        output.value = url + separator + params.toString();
+        copyBtn.disabled = false;
+      }
+
+      // Attach listeners
+      var inputs = document.querySelectorAll('input, select');
+      for (var i = 0; i < inputs.length; i++) {
+        inputs[i].addEventListener('input', update);
+        inputs[i].addEventListener('change', update);
+      }
+
+      // Copy
+      document.getElementById('copy-btn').addEventListener('click', function() {
+        var output = document.getElementById('output');
+        if (navigator.clipboard) {
+          navigator.clipboard.writeText(output.value).then(function() {
+            showToast('Copied to clipboard!');
+          });
+        } else {
+          output.select();
+          document.execCommand('copy');
+          showToast('Copied!');
+        }
+      });
+
+      // Reset
+      document.getElementById('reset-btn').addEventListener('click', function() {
+        document.getElementById('url').value = '';
+        sourceSelect.value = '';
+        mediumSelect.value = '';
+        initiativeSelect.value = '';
+        goalSelect.value = '';
+        document.getElementById('name').value = '';
+        document.getElementById('content').value = '';
+        document.getElementById('custom-source').value = '';
+        document.getElementById('custom-source-field').style.display = 'none';
+        document.getElementById('date').value = yyyy + '_' + mm;
+        update();
+      });
+
+      function showToast(msg) {
+        var toast = document.getElementById('toast');
+        toast.textContent = msg;
+        toast.classList.add('show');
+        setTimeout(function() { toast.classList.remove('show'); }, 2000);
+      }
+    })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## What

Adds the GoodDollar UTM Builder — a self-contained browser tool for generating correctly-formatted UTM tracking URLs. Enforces the org-wide naming standard via dropdowns (no free-typing, no typos).

**Live at:** https://gooddollar.github.io/data-team/utm-builder/

## Changes

- \	ools/utm-builder/index.html\ — the tool (dark-themed, GoodDollar-branded, zero dependencies)
- \	ools/utm-builder/config.json\ — controlled taxonomy: sources, mediums, initiatives, goals
- \	ools/utm-builder/UTM_STANDARD.md\ — org-wide UTM naming standard, per-channel quick references, governance
- \	ools/utm-builder/README.md\ — tool landing page with live link and maintainer instructions
- \.github/workflows/dbt-docs.yml\ — renamed to 'publish site'; now deploys UTM builder to \/utm-builder/\ alongside dbt docs at \/onchain-analytics/\ (existing path preserved)
- \README.md\ — updated repo structure tree, added UTM builder to documentation section

## Deployment

Merging this triggers the CI automatically. The tool will be live within ~3 minutes of merge.